### PR TITLE
Fix missing resource_bundle_accessor.h header for Tuist compatibility

### DIFF
--- a/Resources/include/resource_bundle_accessor.h
+++ b/Resources/include/resource_bundle_accessor.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+#if SWIFT_PACKAGE
+#define SWIFTPM_MODULE_BUNDLE [NSBundle bundleForClass:[YandexMapsMobileSwiftResources class]]
+#else
+#define SWIFTPM_MODULE_BUNDLE [NSBundle bundleForClass:[YandexMapsMobileSwiftResources class]]
+#endif


### PR DESCRIPTION
  ## Summary
  - Add missing `resource_bundle_accessor.h` header file to fix compilation errors when using Tuist cache
  - The header defines the `SWIFTPM_MODULE_BUNDLE` macro required for Swift Package Manager resource bundle access

  ## Problem
  When running `tuist cache --external-only`, the build fails with:
  ❌ 'resource_bundle_accessor.h' file not found (in target 'YandexMapsMobileFullResources' from project
  'YandexMapsMobileFull')

  The `Resources.m` file imports `resource_bundle_accessor.h` but this header was missing from the
  `Resources/include/` directory.

  ## Solution
  Added the missing header file with proper Swift Package Manager macros to enable resource bundle access in both
  Swift Package and non-Swift Package contexts.

  ## Test plan
  - [x] Verified `tuist cache --external-only` now completes successfully
  - [x] No compilation errors when building YandexMapsMobileFullResources target